### PR TITLE
v1.2

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# https://help.github.com/articles/dealing-with-line-endings/
+
+*.py eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ doc/
 .DS_*
 .idea
 .secret
+*.pyc
 credentials.yml
 venv/

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Nagios / Icinga Plugins
 
-A fork of https://github.com/wershlak/nagios_plugins, focused on feature enhancements to the Cisco Stack plugin (which is originally a Python rewrite of [check_snmp_cisco_stack.pl](https://exchange.nagios.org/directory/Plugins/Hardware/Network-Gear/Cisco/Check-cisco-3750-stack-status/details)).
+A fork of <https://github.com/wershlak/nagios_plugins> focused on feature enhancements to the Cisco Stack plugin (which is originally a Python rewrite of [check_snmp_cisco_stack.pl](https://exchange.nagios.org/directory/Plugins/Hardware/Network-Gear/Cisco/Check-cisco-3750-stack-status/details)).
 
 Current enhancements include:
+
 * SNMP version 2(c) and 3 (SNMPv3) support.
-* Support of all SNMP parameters, as detailed at https://net-snmp.svn.sourceforge.net/svnroot/net-snmp/trunk/net-snmp/python/README.
+* Support of all SNMP parameters, as detailed at <https://net-snmp.svn.sourceforge.net/svnroot/net-snmp/trunk/net-snmp/python/README>.
 	* Allows for any combination of SNMPv3 parameters.
 	* Provides for setting of timeouts, retries, remote port, and all other current and future parameters.
 	* Only connection-related options have been tested / are supported.  Some advanced options may cause the program to behave unexpectedly.
@@ -12,7 +13,7 @@ Current enhancements include:
 * Option for setting expected size range of stack ring.
 * Show # of members in output, and show in sorted order.
 * Supplying of secrets / passwords (community string / AuthPass / PrivPass) from a keyed file (or files) for security.
-	* See https://www.netmeister.org/blog/passing-passwords.html.
+	* See <https://www.netmeister.org/blog/passing-passwords.html>.
 * Minor performance optimizations.
 
 Full backwards compatibility with the forked version is currently maintained.
@@ -29,44 +30,45 @@ Full backwards compatibility with the forked version is currently maintained.
 ### Basic Usage
 
 Traditional examples, INSECURE!  Uses SNMPv1, and passwords passed on the command-line.
- * See https://www.netmeister.org/blog/passing-passwords.html.
+
+* See <https://www.netmeister.org/blog/passing-passwords.html>.
 
 #### Insecure Cisco IOS Setup
 
-    snmp-server community insecureCommunityString RO
+	snmp-server community insecureCommunityString RO
 
 #### Insecure Command-Line Examples
 
-    $ ./check_cisco_stack.py -H switch.example.com --snmp-Community insecureCommunityString
+	./check_cisco_stack.py -H switch.example.com --snmp-Community insecureCommunityString
 
 ... or slightly better (still not using SNMPv3):
 
-    $ ./check_cisco_stack.py -H switch.example.com --community-file ~/snmp.auth --community-key switch1
+	./check_cisco_stack.py -H switch.example.com --community-file ~/snmp.auth --community-key switch1
 
 Where `~/snmp.auth` is a "Java" properties file, such as:
 
-    switch1=somePassword1
-    switch2=somePassword2
+	switch1=somePassword1
+	switch2=somePassword2
 
 #### Nagios / Icinga 1.x Configuration Samples
 
 Create a command definition
 
-    # 'check_cisco_stack' command definition
-    define command{
-      command_name    check_cisco_stack
-      command_line    $USER1$/check_cisco_stack.py -H $HOSTADDRESS$ $ARG1$
-    }
+	# 'check_cisco_stack' command definition
+	define command{
+		command_name    check_cisco_stack
+		command_line    $USER1$/check_cisco_stack.py -H $HOSTADDRESS$ $ARG1$
+	}
 
 Define a service for the stack
 
-    define service{
-      use   generic-service   ; Inherit default values from a template
-      servicegroups   <group name> ;
-      host_name <stack hostname>
-      service_description Cisco Stack
-      check_command check_cisco_stack! -H <ip address> -c <community>
-    }
+	define service{
+		use   generic-service   ; Inherit default values from a template
+		servicegroups   <group name> ;
+		host_name <stack hostname>
+		service_description Cisco Stack
+		check_command check_cisco_stack! -H <ip address> -c <community>
+	}
 
 ### SNMPv3 Usage
 
@@ -74,52 +76,52 @@ Define a service for the stack
 
 (Good) Simple (strong authentication):
 
-    snmp-server group zzz-stackview v3 auth
-    snmp-server user zzz-stackmonitor zzz-stackview v3 auth sha somePassword
+	snmp-server group zzz-stackview v3 auth
+	snmp-server user zzz-stackmonitor zzz-stackview v3 auth sha somePassword
 
 (Better) Add some principles of least privilege:
 
-    ! cswSwitchInfoEntry.1
-    snmp-server view zzz-stackview 1.3.6.1.4.1.9.9.500.1.2.1.1.1 included
-    ! cswSwitchInfoEntry.6
-    snmp-server view zzz-stackview 1.3.6.1.4.1.9.9.500.1.2.1.1.6 included
-    ! cswGlobals.3
-    snmp-server view zzz-stackview 1.3.6.1.4.1.9.9.500.1.1.3 included
-    snmp-server group zzz-stackview v3 auth read zzz-stackview
-    snmp-server user zzz-stackmonitor zzz-stackview v3 auth sha somePassword
+	! cswSwitchInfoEntry.1
+	snmp-server view zzz-stackview 1.3.6.1.4.1.9.9.500.1.2.1.1.1 included
+	! cswSwitchInfoEntry.6
+	snmp-server view zzz-stackview 1.3.6.1.4.1.9.9.500.1.2.1.1.6 included
+	! cswGlobals.3
+	snmp-server view zzz-stackview 1.3.6.1.4.1.9.9.500.1.1.3 included
+	snmp-server group zzz-stackview v3 auth read zzz-stackview
+	snmp-server user zzz-stackmonitor zzz-stackview v3 auth sha somePassword
 
 (Best) Add privacy (encryption), replacing only the last line from above:
 
-    snmp-server user zzz-stackmonitor zzz-stackview v3 auth sha someAuthPassword priv aes 128 somePrivPassword
+	snmp-server user zzz-stackmonitor zzz-stackview v3 auth sha someAuthPassword priv aes 128 somePrivPassword
 
-Note that only "AES" (default 128, not 192 or 256) and "DES" (not 3DES) are supported.  See http://www.net-snmp.org/wiki/index.php/Strong_Authentication_or_Encryption.
+Note that only "AES" (default 128, not 192 or 256) and "DES" (not 3DES) are supported.  See <http://www.net-snmp.org/wiki/index.php/Strong_Authentication_or_Encryption>.
 
 #### Secure Command-Line Examples
 
 authNoPriv:
 
-    $ ./check_cisco_stack.py -H switch.example.com --snmp-Version 3 \
-      --snmp-SecName zzz-stackmonitor --snmp-SecLevel 'authNoPriv' \
-      --snmp-AuthProto SHA --auth-file ~/snmp.auth --auth-key switch1
+	$ ./check_cisco_stack.py -H switch.example.com --snmp-Version 3 \
+		--snmp-SecName zzz-stackmonitor --snmp-SecLevel 'authNoPriv' \
+		--snmp-AuthProto SHA --auth-file ~/snmp.auth --auth-key switch1
 
 authPriv:
 
-    $ ./check_cisco_stack.py -H switch.example.com --snmp-Version 3 \
-      --snmp-SecName zzz-stackmonitor --snmp-SecLevel 'authPriv' \
-      --snmp-AuthProto SHA --auth-file ~/snmp.auth --auth-key switch1-auth \
-      --snmp-PrivProto AES --priv-key switch1-priv
+	$ ./check_cisco_stack.py -H switch.example.com --snmp-Version 3 \
+		--snmp-SecName zzz-stackmonitor --snmp-SecLevel 'authPriv' \
+		--snmp-AuthProto SHA --auth-file ~/snmp.auth --auth-key switch1-auth \
+		--snmp-PrivProto AES --priv-key switch1-priv
 
 ### Sample Outputs
 
-    Cisco Stack OK - 5 Members:: 1: ready, 2: ready, 3: ready, 4: ready, 5: ready, Stack Ring is redundant
+	Cisco Stack OK - 5 Members:: 1: ready, 2: ready, 3: ready, 4: ready, 5: ready, Stack Ring is redundant.
 
 or in VSS mode:
 
-    Cisco Stack OK - VSSwitchMode: multiNode, cvsSwitchConvertingStatus: false. VSL:: 102: UP (2/2), 103: UP (2/2). Chassis:: 2: active, up 111 days, 3:19:03, 3: standby, up 111 days, 3:19:03.
+	Cisco Stack OK - VSSwitchMode: multiNode, cvsSwitchConvertingStatus: false. VSL:: 102: UP (2/2), 103: UP (2/2). Chassis:: 2: active, up 111 days, 3:19:03, 3: standby, up 111 days, 3:19:03.
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/ziesemer/wershlak-nagios_plugins.
+Bug reports and pull requests are welcome on GitHub at <https://github.com/ziesemer/wershlak-nagios_plugins>.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Full backwards compatibility with the forked version is currently maintained.
 ## Installation
 
 1. Ensure that the Python library `netsnmp` is installed.
- 1. For CentOS 7, `sudo yum install net-snmp-python`.
+	1. For CentOS 7, `sudo yum install net-snmp-python`.
 2. Copy scripts into the Nagios/Icinga plugin directory.
- 1. `check_cisco_stack.py` is all that is currently required for the Cisco Stack plugin.
+	1. `check_cisco_stack.py` is all that is currently required for the Cisco Stack plugin.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ A fork of https://github.com/wershlak/nagios_plugins, focused on feature enhance
 Current enhancements include:
 * SNMP version 2(c) and 3 (SNMPv3) support.
 * Support of all SNMP parameters, as detailed at https://net-snmp.svn.sourceforge.net/svnroot/net-snmp/trunk/net-snmp/python/README.
- * Allows for any combination of SNMPv3 parameters.
- * Provides for setting of timeouts, retries, remote port, and all other current and future parameters.
- * Only connection-related options have been tested / are supported.  Some advanced options may cause the program to behave unexpectedly.
+	* Allows for any combination of SNMPv3 parameters.
+	* Provides for setting of timeouts, retries, remote port, and all other current and future parameters.
+	* Only connection-related options have been tested / are supported.  Some advanced options may cause the program to behave unexpectedly.
 * Support for Cisco VSS (Virtual Switching System) mode.
 * Option for setting expected size range of stack ring.
 * Show # of members in output, and show in sorted order.
 * Supplying of secrets / passwords (community string / AuthPass / PrivPass) from a keyed file (or files) for security.
- * See https://www.netmeister.org/blog/passing-passwords.html.
+	* See https://www.netmeister.org/blog/passing-passwords.html.
 * Minor performance optimizations.
 
 Full backwards compatibility with the forked version is currently maintained.

--- a/README.md
+++ b/README.md
@@ -1,43 +1,125 @@
-# Nagios Plugins
+# Nagios / Icinga Plugins
 
-Creating a repo for some nagios plugins I've done.
+A fork of https://github.com/wershlak/nagios_plugins, focused on feature enhancements to the Cisco Stack plugin (which is originally a Python rewrite of [check_snmp_cisco_stack.pl](https://exchange.nagios.org/directory/Plugins/Hardware/Network-Gear/Cisco/Check-cisco-3750-stack-status/details)).
+
+Current enhancements include:
+* SNMP version 2(c) and 3 (SNMPv3) support.
+* Support of all SNMP parameters, as detailed at https://net-snmp.svn.sourceforge.net/svnroot/net-snmp/trunk/net-snmp/python/README.
+ * Allows for any combination of SNMPv3 parameters.
+ * Provides for setting of timeouts, retries, remote port, and all other current and future parameters.
+ * Only connection-related options have been tested / are supported.  Some advanced options may cause the program to behave unexpectedly.
+* Support for Cisco VSS (Virtual Switching System) mode.
+* Option for setting expected size range of stack ring.
+* Show # of members in output, and show in sorted order.
+* Supplying of secrets / passwords (community string / AuthPass / PrivPass) from a keyed file (or files) for security.
+ * See https://www.netmeister.org/blog/passing-passwords.html.
+* Minor performance optimizations.
+
+Full backwards compatibility with the forked version is currently maintained.
 
 ## Installation
 
-copy scripts into nagios plugin directory
-
+1. Ensure that the Python library `netsnmp` is installed.
+ 1. For CentOS 7, `sudo yum install net-snmp-python`.
+2. Copy scripts into the Nagios/Icinga plugin directory.
+ 1. `check_cisco_stack.py` is all that is currently required for the Cisco Stack plugin.
 
 ## Usage
 
+### Basic Usage
+
+Traditional examples, INSECURE!  Uses SNMPv1, and passwords passed on the command-line.
+ * See https://www.netmeister.org/blog/passing-passwords.html.
+
+#### Insecure Cisco IOS Setup
+
+    snmp-server community insecureCommunityString RO
+
+#### Insecure Command-Line Examples
+
+    $ ./check_cisco_stack.py -H switch.example.com --snmp-Community insecureCommunityString
+
+... or slightly better (still not using SNMPv3):
+
+    $ ./check_cisco_stack.py -H switch.example.com --community-file ~/snmp.auth --community-key switch1
+
+Where `~/snmp.auth` is a "Java" properties file, such as:
+
+    switch1=somePassword1
+    switch2=somePassword2
+
+#### Nagios / Icinga 1.x Configuration Samples
+
 Create a command definition
 
-        # 'check_cisco_stack' command definition
-        define command{
-             command_name    check_cisco_stack
-             command_line    $USER1$/check_cisco_stack.py -H $HOSTADDRESS$ $ARG1$
-        }
+    # 'check_cisco_stack' command definition
+    define command{
+      command_name    check_cisco_stack
+      command_line    $USER1$/check_cisco_stack.py -H $HOSTADDRESS$ $ARG1$
+    }
 
 Define a service for the stack
 
-        define service{
-          use   generic-service   ; Inherit default values from a template
-          servicegroups   <group name> ;
-          host_name <stack hostname>
-          service_description Cisco Stack
-          check_command check_cisco_stack! -H <ip address> -c <community>
-        }
+    define service{
+      use   generic-service   ; Inherit default values from a template
+      servicegroups   <group name> ;
+      host_name <stack hostname>
+      service_description Cisco Stack
+      check_command check_cisco_stack! -H <ip address> -c <community>
+    }
 
-Sample output:
+### SNMPv3 Usage
 
-        Cisco Stack OK - 5 Members:: 1: ready, 2: ready, 3: ready, 4: ready, 5: ready, Stack Ring is redundant
+#### SNMPv3 Cisco IOS Setup
+
+(Good) Simple (strong authentication):
+
+    snmp-server group zzz-stackview v3 auth
+    snmp-server user zzz-stackmonitor zzz-stackview v3 auth sha somePassword
+
+(Better) Add some principles of least privilege:
+
+    ! cswSwitchInfoEntry.1
+    snmp-server view zzz-stackview 1.3.6.1.4.1.9.9.500.1.2.1.1.1 included
+    ! cswSwitchInfoEntry.6
+    snmp-server view zzz-stackview 1.3.6.1.4.1.9.9.500.1.2.1.1.6 included
+    ! cswGlobals.3
+    snmp-server view zzz-stackview 1.3.6.1.4.1.9.9.500.1.1.3 included
+    snmp-server group zzz-stackview v3 auth read zzz-stackview
+    snmp-server user zzz-stackmonitor zzz-stackview v3 auth sha somePassword
+
+(Best) Add privacy (encryption), replacing only the last line from above:
+
+    snmp-server user zzz-stackmonitor zzz-stackview v3 auth sha someAuthPassword priv aes 128 somePrivPassword
+
+Note that only "AES" (default 128, not 192 or 256) and "DES" (not 3DES) are supported.  See http://www.net-snmp.org/wiki/index.php/Strong_Authentication_or_Encryption.
+
+#### Secure Command-Line Examples
+
+authNoPriv:
+
+    $ ./check_cisco_stack.py -H switch.example.com --snmp-Version 3 \
+      --snmp-SecName zzz-stackmonitor --snmp-SecLevel 'authNoPriv' \
+      --snmp-AuthProto SHA --auth-file ~/snmp.auth --auth-key switch1
+
+authPriv:
+
+    $ ./check_cisco_stack.py -H switch.example.com --snmp-Version 3 \
+      --snmp-SecName zzz-stackmonitor --snmp-SecLevel 'authPriv' \
+      --snmp-AuthProto SHA --auth-file ~/snmp.auth --auth-key switch1-auth \
+      --snmp-PrivProto AES --priv-key switch1-priv
+
+### Sample Outputs
+
+    Cisco Stack OK - 5 Members:: 1: ready, 2: ready, 3: ready, 4: ready, 5: ready, Stack Ring is redundant
 
 or in VSS mode:
 
-        Cisco Stack OK - VSSwitchMode: multiNode, cvsSwitchConvertingStatus: false. VSL:: 102: UP (2/2), 103: UP (2/2). Chassis:: 2: active, up 111 days, 3:19:03, 3: standby, up 111 days, 3:19:03. 
+    Cisco Stack OK - VSSwitchMode: multiNode, cvsSwitchConvertingStatus: false. VSL:: 102: UP (2/2), 103: UP (2/2). Chassis:: 2: active, up 111 days, 3:19:03, 3: standby, up 111 days, 3:19:03.
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/wershlak/nagios_plugins.
+Bug reports and pull requests are welcome on GitHub at https://github.com/ziesemer/wershlak-nagios_plugins.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ Define a service for the stack
           check_command check_cisco_stack! -H <ip address> -c <community>
         }
 
+Sample output:
+
+        Cisco Stack OK - 5 Members:: 1: ready, 2: ready, 3: ready, 4: ready, 5: ready, Stack Ring is redundant
+
+or in VSS mode:
+
+        Cisco Stack OK - VSSwitchMode: multiNode, cvsSwitchConvertingStatus: false. VSL:: 102: UP (2/2), 103: UP (2/2). Chassis:: 2: active, up 111 days, 3:19:03, 3: standby, up 111 days, 3:19:03. 
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/wershlak/nagios_plugins.

--- a/RangeTests.py
+++ b/RangeTests.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+
+import unittest
+from check_cisco_stack import Range, RangeValueError
+
+class RangeTests(unittest.TestCase):
+	
+	@classmethod
+	def setUpClass(cls):
+		cls.doDebug = False
+		cls.firstPrint = False
+	
+	def t(self, r, n, b):
+		if(self.doDebug):
+			if(not(self.firstPrint)):
+				print
+				self.firstPrint = True
+			print("  Testing {0} with {1} is {2}...".format(r.str, n, b))
+		self.assertEqual(r.test(n), b)
+	
+	def testExact(self):
+		r = Range("10")
+		self.t(r, 9, False)
+		self.t(r, 10, True)
+		self.t(r, 11, False)
+		self.t(r, None, False)
+	
+	def testInclusive(self):
+		r = Range("[10,20]")
+		self.t(r, 9, False)
+		self.t(r, 10, True)
+		self.t(r, 11, True)
+		self.t(r, 19, True)
+		self.t(r, 20, True)
+		self.t(r, 21, False)
+	
+	def testExclusive(self):
+		r = Range("(10,20)")
+		self.t(r, 9, False)
+		self.t(r, 10, False)
+		self.t(r, 11, True)
+		self.t(r, 19, True)
+		self.t(r, 20, False)
+		self.t(r, 21, False)
+	
+	def testInfInclusive(self):
+		r = Range("[,]")
+		self.t(r, float("-inf"), True)
+		self.t(r, 0, True)
+		self.t(r, float("inf"), True)
+	
+	def testInfInclusiveStart(self):
+		r = Range("[,10]")
+		self.t(r, float("-inf"), True)
+		self.t(r, 0, True)
+		self.t(r, 10, True)
+		self.t(r, float("inf"), False)
+	
+	def testInfInclusiveEnd(self):
+		r = Range("[10,]")
+		self.t(r, 9, False)
+		self.t(r, 10, True)
+		self.t(r, float("inf"), True)
+	
+	def testInfExclusive(self):
+		r = Range("(,)")
+		self.t(r, float("-inf"), False)
+		self.t(r, -1, True)
+		self.t(r, 0, True)
+		self.t(r, 1, True)
+		self.t(r, float("inf"), False)
+	
+	def testInclExcl(self):
+		r = Range("[10,20)")
+		self.t(r, 9, False)
+		self.t(r, 10, True)
+		self.t(r, 11, True)
+		self.t(r, 19, True)
+		self.t(r, 20, False)
+		self.t(r, 21, False)
+		
+	def testExclIncl(self):
+		r = Range("(10,20]")
+		self.t(r, 9, False)
+		self.t(r, 10, False)
+		self.t(r, 11, True)
+		self.t(r, 19, True)
+		self.t(r, 20, True)
+		self.t(r, 21, False)
+	
+	def testEmptyRangeError(self):
+		with self.assertRaises(ValueError):
+			Range("")
+	
+	def testOnlyCommaError(self):
+		with self.assertRaises(RangeValueError):
+			Range(",")
+	
+	def testTooManyValuesError(self):
+		with self.assertRaises(RangeValueError):
+			Range("[1,2,3]")
+	
+	def testInvalidStartError(self):
+		with self.assertRaises(RangeValueError):
+			Range("1,2]")
+		with self.assertRaises(RangeValueError):
+			Range("x1,2]")
+		with self.assertRaises(RangeValueError):
+			Range(",2]")
+	
+	def testInvalidEndError(self):
+		with self.assertRaises(RangeValueError):
+			Range("[1,2")
+		with self.assertRaises(RangeValueError):
+			Range("[1,2x")
+		with self.assertRaises(RangeValueError):
+			Range("[1,")
+	
+	def testBackwardsError(self):
+		with self.assertRaises(RangeValueError):
+			Range("[2,1]")
+
+if __name__ == '__main__':
+	suite = unittest.TestLoader().loadTestsFromTestCase(RangeTests)
+	unittest.TextTestRunner(verbosity=2).run(suite)

--- a/check_cisco_stack.py
+++ b/check_cisco_stack.py
@@ -45,9 +45,10 @@
 #                   (ziesemer)
 # 2016-12-03 - 1.4: Fix "zero length field name in format" error on Python 2.6.
 #                   (ziesemer)
-# 2017-01-02 - 1.5-dev: Add option for setting expected size range of stack ring,
+# 2017-01-02 - 1.5: Add option for setting expected size range of stack ring,
 #                   don't consider any stack ring status for expected 1-member stacks,
 #                   and otherwise return a warning if the expected size range is not matched.
+#                   Minor performance optimization for stack_state().
 #                   (ziesemer)
 #
 # ======================= LICENSE =============================
@@ -84,7 +85,7 @@ import traceback # for error handling
 
 # Global program variables
 __program_name__ = "Cisco Stack"
-__version__ = "1.5-dev"
+__version__ = "1.5"
 
 ciscoMgmt = ".1.3.6.1.4.1.9.9"
 
@@ -402,19 +403,21 @@ def get_stack_info(options):
 # removed - The switch is removed from the stack."
 
 def stack_state(x):
-	return {
-		1: "waiting",
-		2: "progressing",
-		3: "added",
-		4: "ready",
-		5: "sdmMismatch",
-		6: "verMismatch",
-		7: "featureMismatch",
-		8: "newMasterInit",
-		9: "provisioned",
-		10: "invalid",
-		11: "removed",
-	}.get(x, "UNKNOWN")
+	return stackStates.get(x, "UNKNOWN")
+
+stackStates = {
+	1: "waiting",
+	2: "progressing",
+	3: "added",
+	4: "ready",
+	5: "sdmMismatch",
+	6: "verMismatch",
+	7: "featureMismatch",
+	8: "newMasterInit",
+	9: "provisioned",
+	10: "invalid",
+	11: "removed",
+}
 
 
 ###############################################################

--- a/check_cisco_stack.py
+++ b/check_cisco_stack.py
@@ -35,6 +35,7 @@
 # 2015-11-27: Version 1.0 released (Moving to PROD)
 # 2015-12-04 - 1.1: Now marking all states other than "ready" as critical
 # 2015-06-06 - 1.2: Add SNMP version 2 support.
+#                   Return an exit status code of 3/UNKNOWN if -v / --version is used.
 #                   (ziesemer)
 #
 # ======================= LICENSE =============================
@@ -130,7 +131,7 @@ def parse_args():
             usage()
         elif o in ("-v", "--version"):
             print "{0} plugin version {1}".format(__program_name__, __version__)
-            sys.exit(0)
+            sys.exit(UNKNOWN)
         elif o in ("-H", "--host"):
             options['remote_ip'] = a
         elif o in ("-c", "--community"):

--- a/check_cisco_stack.py
+++ b/check_cisco_stack.py
@@ -73,7 +73,7 @@ import sys       # exit
 import traceback # for error handling
 
 # Global program variables
-__program_name__ = 'Cisco Stack'
+__program_name__ = "Cisco Stack"
 __version__ = 1.2
 
 
@@ -90,11 +90,11 @@ UNKNOWN = 3
 
 def exit_status(x):
 	return {
-		0: 'OK',
-		1: 'WARNING',
-		2: 'CRITICAL',
-		3: 'UNKNOWN'
-	}.get(x, 'UNKNOWN')
+		0: "OK",
+		1: "WARNING",
+		2: "CRITICAL",
+		3: "UNKNOWN"
+	}.get(x, "UNKNOWN")
 
 
 ###############################################################
@@ -103,7 +103,7 @@ def exit_status(x):
 #
 ###############################################################
 def usage():
-	print """
+	print("""
 \t-h --help\t\t\t- Prints out this help message.
 \t-v --version\t\t\t- Prints the version number.
 \t-H --host <ip_address>\t\t- IP address of the cisco stack.
@@ -112,7 +112,7 @@ def usage():
 \t   --community-file <file>\t- File to read SNMP community string from.
 \t   --snmp-protocol-version <#>\t- SNMP protocol version.
 \t-d --debug\t\t\t- Verbose mode for debugging.
-"""
+""")
 	sys.exit(UNKNOWN)
 
 
@@ -137,18 +137,18 @@ def parse_args():
 				"snmp-protocol-version=", "debug"])
 	except getopt.GetoptError, err:
 		# print help information and exit:
-		print str(err)    # will print something like "option -a not recognized"
+		print(str(err))    # will print something like "option -a not recognized"
 		usage()
 	for o, a in opts:
 		if o in ("-h", "--help"):
 			usage()
 		elif o in ("-v", "--version"):
-			print "{0} plugin version {1}".format(__program_name__, __version__)
+			print("{0} plugin version {1}".format(__program_name__, __version__))
 			sys.exit(UNKNOWN)
 		elif o in ("-H", "--host"):
-			options['remote_ip'] = a
+			options["remote_ip"] = a
 		elif o in ("-c", "--community"):
-			options['community'] = a
+			options["community"] = a
 		elif o in ("--community-key"):
 			options["community-key"] = a
 		elif o in ("--community-file"):
@@ -158,9 +158,9 @@ def parse_args():
 		elif o in ("-d", "--debug"):
 			logging.basicConfig(
 				level=logging.DEBUG,
-				format='%(asctime)s - %(funcName)s - %(message)s'
+				format="%(asctime)s - %(funcName)s - %(message)s"
 			)
-			logging.debug('*** Debug mode started ***')
+			logging.debug("*** Debug mode started ***")
 		else:
 			assert False, "unhandled option: " + o
 	
@@ -179,18 +179,18 @@ def parse_args():
 	elif(options["community"] is None):
 		options["community"] = "Public"
 	
-	logging.debug('Printing initial variables')
-	logging.debug('remote_ip: {0}'.format(options['remote_ip']))
-	logging.debug('community: {0}'.format(options['community']))
-	logging.debug('snmp-protocol-version: {0}'.format(options['snmp-protocol-version']))
-	if options['remote_ip'] is None:
-		print "Requires host to check"
+	logging.debug("Printing initial variables")
+	logging.debug("remote_ip: {0}".format(options["remote_ip"]))
+	logging.debug("community: {0}".format(options["community"]))
+	logging.debug("snmp-protocol-version: {0}".format(options["snmp-protocol-version"]))
+	if options["remote_ip"] is None:
+		print("Requires host to check")
 		usage()
 	
 	snmp_kwargs = {
 		"DestHost" : options["remote_ip"],
 		"Version" : options["snmp-protocol-version"],
-		"Community" : options['community']
+		"Community" : options["community"]
 	}
 	options["snmp_kwargs"] = snmp_kwargs
 	
@@ -204,10 +204,10 @@ def parse_args():
 # :param message: Message to print
 #
 ###############################################################
-def plugin_exit(exitcode, message=''):
-	logging.debug('Exiting with status {0}. Message: {1}'.format(exitcode, message))
+def plugin_exit(exitcode, message=""):
+	logging.debug("Exiting with status {0}. Message: {1}".format(exitcode, message))
 	status = exit_status(exitcode)
-	print '{0} {1} - {2}'.format(__program_name__, status, message)
+	print("{0} {1} - {2}".format(__program_name__, status, message))
 	sys.exit(exitcode)
 
 
@@ -238,26 +238,26 @@ def plugin_exit(exitcode, message=''):
 ###############################################################
 def get_stack_info(options):
 	member_table = {}
-	stack_table_oid = netsnmp.VarList(netsnmp.Varbind('.1.3.6.1.4.1.9.9.500.1.2.1.1.1'))
-	logging.debug('Walking stack table -- ')
+	stack_table_oid = netsnmp.VarList(netsnmp.Varbind(".1.3.6.1.4.1.9.9.500.1.2.1.1.1"))
+	logging.debug("Walking stack table -- ")
 	netsnmp.snmpwalk(stack_table_oid, **options["snmp_kwargs"])
 	if not stack_table_oid:
-		plugin_exit(CRITICAL, 'Unable to retrieve SNMP stack table')
+		plugin_exit(CRITICAL, "Unable to retrieve SNMP stack table")
 	for member in stack_table_oid:
-		logging.debug('Member info: {0}'.format(member.print_str()))
-		a = {'number': member.val, 'index': member.tag.rsplit('.').pop()}
-		member_table[a['index']] = a
-	stack_status_oid = netsnmp.VarList(netsnmp.Varbind('.1.3.6.1.4.1.9.9.500.1.2.1.1.6'))
-	logging.debug('Walking stack status -- ')
+		logging.debug("Member info: {0}".format(member.print_str()))
+		a = {"number": member.val, "index": member.tag.rsplit(".").pop()}
+		member_table[a["index"]] = a
+	stack_status_oid = netsnmp.VarList(netsnmp.Varbind(".1.3.6.1.4.1.9.9.500.1.2.1.1.6"))
+	logging.debug("Walking stack status -- ")
 	netsnmp.snmpwalk(stack_status_oid, **options["snmp_kwargs"])
 	if not stack_status_oid:
-		plugin_exit(CRITICAL, 'Unable to retrieve SNMP stack status')
+		plugin_exit(CRITICAL, "Unable to retrieve SNMP stack status")
 	for member in stack_status_oid:
-		logging.debug('Member info: {0}'.format(member.print_str()))
-		index = member.tag.rsplit('.').pop()
-		member_table[index]['status_num'] = member.val
-		member_table[index]['status'] = stack_state(member.val)
-	logging.debug('Stack info table to return: {0}'.format(member_table))
+		logging.debug("Member info: {0}".format(member.print_str()))
+		index = member.tag.rsplit(".").pop()
+		member_table[index]["status_num"] = member.val
+		member_table[index]["status"] = stack_state(int(member.val))
+	logging.debug("Stack info table to return: {0}".format(member_table))
 	return member_table
 
 
@@ -305,18 +305,18 @@ def get_stack_info(options):
 
 def stack_state(x):
 	return {
-		'1': 'waiting',
-		'2': 'progressing',
-		'3': 'added',
-		'4': 'ready',
-		'5': 'sdmMismatch',
-		'6': 'verMismatch',
-		'7': 'featureMismatch',
-		'8': 'newMasterInit',
-		'9': 'provisioned',
-		'10': 'invalid',
-		'11': 'removed',
-	}.get(x, 'UNKNOWN')
+		1: "waiting",
+		2: "progressing",
+		3: "added",
+		4: "ready",
+		5: "sdmMismatch",
+		6: "verMismatch",
+		7: "featureMismatch",
+		8: "newMasterInit",
+		9: "provisioned",
+		10: "invalid",
+		11: "removed",
+	}.get(x, "UNKNOWN")
 
 
 ###############################################################
@@ -332,12 +332,12 @@ def stack_state(x):
 #
 ###############################################################
 def get_ring_status(options):
-	ring_status_oid = netsnmp.Varbind('.1.3.6.1.4.1.9.9.500.1.1.3.0')
-	logging.debug('Getting stack ring redundancy status -- ')
+	ring_status_oid = netsnmp.Varbind(".1.3.6.1.4.1.9.9.500.1.1.3.0")
+	logging.debug("Getting stack ring redundancy status -- ")
 	netsnmp.snmpget(ring_status_oid, **options["snmp_kwargs"])
 	if not ring_status_oid:
-		plugin_exit(CRITICAL, 'Unable to retrieve SNMP ring status')
-	logging.debug('Ring status: {0}'.format(ring_status_oid.print_str()))
+		plugin_exit(CRITICAL, "Unable to retrieve SNMP ring status")
+	logging.debug("Ring status: {0}".format(ring_status_oid.print_str()))
 	stack_ring_status = ring_status_oid.val
 	return stack_ring_status
 
@@ -354,21 +354,21 @@ def get_ring_status(options):
 def evaluate_results(stack, ring):
 	message = [str(len(stack)), " Members:: "]
 	result = OK
-	logging.debug('Checking each stack member')
+	logging.debug("Checking each stack member")
 	for i, member in sorted(stack.iteritems()):
-		logging.debug('Member {0} is {1}'.format(member['number'], member['status']))
-		message.append("{0}: {1}, ".format(member['number'], member['status']))
-		if member['status_num'] is not '4':
+		logging.debug("Member {0} is {1}".format(member["number"], member["status"]))
+		message.append("{0}: {1}, ".format(member["number"], member["status"]))
+		if member["status_num"] is not "4":
 			result = CRITICAL
-			logging.debug('Status changed to CRITICAL')
-	if ring == '1':
+			logging.debug("Status changed to CRITICAL")
+	if ring == "1":
 		message.append("Stack Ring is redundant")
 	else:
 		message.append("Stack Ring is non-redundant")
 		if result == OK:
 			result = WARNING
-			logging.debug('Status changed to WARNING')
-	message = ''.join(message)
+			logging.debug("Status changed to WARNING")
+	message = "".join(message)
 	return result, message
 
 

--- a/check_cisco_stack.py
+++ b/check_cisco_stack.py
@@ -17,6 +17,7 @@
 # 3750G
 # 3750X
 # 3850X
+# 6509
 #
 # !!! WARNING !!!
 # See relevant bug reports before using in your environment
@@ -34,12 +35,13 @@
 # ========================= NOTES =============================
 # 2015-11-27: Version 1.0 released (Moving to PROD)
 # 2015-12-04 - 1.1: Now marking all states other than "ready" as critical
-# 2015-06-06 - 1.2: Add SNMP version 2 support.
+# 2016-06-06 - 1.2: Add SNMP version 2 support.
 #                   Return an exit status code of 3/UNKNOWN if -v / --version is used.
 #                   Update standard output to show # of members,
 #                   and to show members in sorted order.
 #                   Allow supplying SNMP community string from keyed file.
 #                   (ziesemer)
+# 2016-06-07 - 1.3: Add support for Cisco VSS (Virtual Switching System) mode.
 #
 # ======================= LICENSE =============================
 #
@@ -65,6 +67,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 # ###############################################################
+import datetime  # for timedelta for VSS uptime.
 import getopt    # for parsing options
 import logging   # for debug option
 import netsnmp   # Requires net-snmp compiled with python bindings
@@ -74,8 +77,9 @@ import traceback # for error handling
 
 # Global program variables
 __program_name__ = "Cisco Stack"
-__version__ = 1.2
+__version__ = 1.3
 
+ciscoMgmt = ".1.3.6.1.4.1.9.9"
 
 ###############################################################
 #
@@ -111,6 +115,7 @@ def usage():
 \t   --community-key <key>\t- Key of key=value pair to read SNMP community string from in file.
 \t   --community-file <file>\t- File to read SNMP community string from.
 \t   --snmp-protocol-version <#>\t- SNMP protocol version.
+\t-m --mode <mode>\t\t- Currently "stack" (default) or "vss".
 \t-d --debug\t\t\t- Verbose mode for debugging.
 """)
 	sys.exit(UNKNOWN)
@@ -127,14 +132,15 @@ def parse_args():
 		("community", None),
 		("community-key", None),
 		("community-file", None),
-		("snmp-protocol-version", 1)
+		("snmp-protocol-version", 1),
+		("mode", "stack")
 	])
 	try:
 		opts, args = getopt.getopt(sys.argv[1:],
-			"hvH:c:d",
+			"hvH:c:m:d",
 			["help", "version", "host=",
 				"community=", "community-key=", "community-file=",
-				"snmp-protocol-version=", "debug"])
+				"mode=", "snmp-protocol-version=", "debug"])
 	except getopt.GetoptError, err:
 		# print help information and exit:
 		print(str(err))    # will print something like "option -a not recognized"
@@ -153,6 +159,11 @@ def parse_args():
 			options["community-key"] = a
 		elif o in ("--community-file"):
 			options["community-file"] = a
+		elif o in ("-m", "--mode"):
+			if a not in ("stack", "vss"):
+				print("Unrecognized mode: " + a)
+				usage()
+			options["mode"] = a
 		elif o in ("--snmp-protocol-version"):
 			options["snmp-protocol-version"] = int(a)
 		elif o in ("-d", "--debug"):
@@ -182,6 +193,7 @@ def parse_args():
 	logging.debug("Printing initial variables")
 	logging.debug("remote_ip: {0}".format(options["remote_ip"]))
 	logging.debug("community: {0}".format(options["community"]))
+	logging.debug("mode: {0}".format(options["mode"]))
 	logging.debug("snmp-protocol-version: {0}".format(options["snmp-protocol-version"]))
 	if options["remote_ip"] is None:
 		print("Requires host to check")
@@ -210,6 +222,21 @@ def plugin_exit(exitcode, message=""):
 	print("{0} {1} - {2}".format(__program_name__, status, message))
 	sys.exit(exitcode)
 
+def ciscoSnmpWalk(options, oidSuffix, errSuffix):
+	logging.debug("Walking %s -- ", errSuffix)
+	oid = netsnmp.VarList(netsnmp.Varbind(ciscoMgmt + oidSuffix))
+	netsnmp.snmpwalk(oid, **options["snmp_kwargs"])
+	if not oid:
+		plugin_exit(CRITICAL, "Unable to retrieve SNMP " + errSuffix)
+	return oid
+
+def ciscoSnmpGet(options, oidSuffix, errSuffix):
+	logging.debug("Getting %s -- ", errSuffix)
+	oid = netsnmp.Varbind(ciscoMgmt + oidSuffix)
+	netsnmp.snmpget(oid, **options["snmp_kwargs"])
+	if not oid:
+		plugin_exit(CRITICAL, "Unable to retrieve SNMP " + errSuffix)
+	return oid
 
 ###############################################################
 #
@@ -238,26 +265,21 @@ def plugin_exit(exitcode, message=""):
 ###############################################################
 def get_stack_info(options):
 	member_table = {}
-	stack_table_oid = netsnmp.VarList(netsnmp.Varbind(".1.3.6.1.4.1.9.9.500.1.2.1.1.1"))
-	logging.debug("Walking stack table -- ")
-	netsnmp.snmpwalk(stack_table_oid, **options["snmp_kwargs"])
-	if not stack_table_oid:
-		plugin_exit(CRITICAL, "Unable to retrieve SNMP stack table")
+	
+	stack_table_oid = ciscoSnmpWalk(options, ".500.1.2.1.1.1", "stack table")
 	for member in stack_table_oid:
 		logging.debug("Member info: {0}".format(member.print_str()))
 		a = {"number": member.val, "index": member.tag.rsplit(".").pop()}
 		member_table[a["index"]] = a
-	stack_status_oid = netsnmp.VarList(netsnmp.Varbind(".1.3.6.1.4.1.9.9.500.1.2.1.1.6"))
-	logging.debug("Walking stack status -- ")
-	netsnmp.snmpwalk(stack_status_oid, **options["snmp_kwargs"])
-	if not stack_status_oid:
-		plugin_exit(CRITICAL, "Unable to retrieve SNMP stack status")
+	
+	stack_status_oid = ciscoSnmpWalk(options, ".500.1.2.1.1.6", "stack status")
 	for member in stack_status_oid:
 		logging.debug("Member info: {0}".format(member.print_str()))
 		index = member.tag.rsplit(".").pop()
 		member_table[index]["status_num"] = member.val
 		member_table[index]["status"] = stack_state(int(member.val))
 	logging.debug("Stack info table to return: {0}".format(member_table))
+	
 	return member_table
 
 
@@ -332,11 +354,7 @@ def stack_state(x):
 #
 ###############################################################
 def get_ring_status(options):
-	ring_status_oid = netsnmp.Varbind(".1.3.6.1.4.1.9.9.500.1.1.3.0")
-	logging.debug("Getting stack ring redundancy status -- ")
-	netsnmp.snmpget(ring_status_oid, **options["snmp_kwargs"])
-	if not ring_status_oid:
-		plugin_exit(CRITICAL, "Unable to retrieve SNMP ring status")
+	ring_status_oid = ciscoSnmpGet(options, ".500.1.1.3.0", "stack ring redundancy status")
 	logging.debug("Ring status: {0}".format(ring_status_oid.print_str()))
 	stack_ring_status = ring_status_oid.val
 	return stack_ring_status
@@ -351,7 +369,7 @@ def get_ring_status(options):
 # :return message: status message string for exit
 #
 ###############################################################
-def evaluate_results(stack, ring):
+def evaluate_stack_results(stack, ring):
 	message = [str(len(stack)), " Members:: "]
 	result = OK
 	logging.debug("Checking each stack member")
@@ -371,6 +389,125 @@ def evaluate_results(stack, ring):
 	message = "".join(message)
 	return result, message
 
+def run_stack(options):
+	stack = get_stack_info(options)
+	ring = get_ring_status(options)
+	return evaluate_stack_results(stack, ring)
+
+def run_vss(options):
+	warning = False
+	critical = False
+	unknown = False
+	
+	message = []
+	
+	cvsSwitchModeOid = ciscoSnmpGet(options, ".388.1.1.4.0", "cvsSwitchMode")
+	
+	message.append("VSSwitchMode: ")
+	
+	vssVal = int(cvsSwitchModeOid.val)
+	if(vssVal == 1):
+		message.append("standalone (ERROR)")
+		critical = True
+	elif(vssVal == 2):
+		message.append("multiNode")
+	else:
+		message.append("UNKNOWN ({:d})".format(vssVal))
+		unknown = True
+	
+	cvsSwitchConvertingStatusOid = ciscoSnmpGet(options, ".388.1.1.5.0", "cvsSwitchConvertingStatus")
+	
+	message.append(", cvsSwitchConvertingStatus: ")
+	
+	vssConvertVal = int(cvsSwitchConvertingStatusOid.val)
+	if(vssConvertVal == 1):
+		message.append("true (ERROR)")
+		critical = True
+	elif(vssConvertVal == 2):
+		message.append("false")
+	else:
+		message.append("UNKNOWN ({:d})".format(vssConvertVal))
+		unknown = True
+	
+	cvsVSLConnectionEntryOid = ciscoSnmpWalk(options, ".388.1.3.1.1", "cvsVSLConnectionEntry")
+	vslTab = oidToTable(cvsVSLConnectionEntryOid)
+	logging.debug("vslTab: %s", vslTab)
+	
+	message.append(". VSL:: ")
+	for link, attribs in sorted(vslTab.iteritems()):
+		message.append("{:d}: ".format(link))
+		status = int(attribs[3])
+		if(status == 1):
+			message.append("UP")
+		elif(status == 2):
+			message.append("down (ERROR)")
+			critical = True
+		else:
+			message.append("UNKNOWN ({:d})".format(status))
+			unknown = True
+		
+		linksConfigured = int(attribs[5])
+		linksOperational = int(attribs[6])
+		message.append(" ({:d}/{:d})".format(linksOperational, linksConfigured))
+		if(linksOperational != linksConfigured):
+			message.append("(WARNING)")
+			warning = True
+		message.append(", ")
+	
+	# Remove last trailing separator.
+	message.pop()
+	
+	cvsChassisEntryOid = ciscoSnmpWalk(options, ".388.1.2.2.1", "cvsChassisEntry")
+	chassisTab = oidToTable(cvsChassisEntryOid)
+	logging.debug("chassisTab: %s", chassisTab)
+	
+	message.append(". Chassis:: ")
+	chassisId = 0
+	for chassis, attribs in sorted(chassisTab.iteritems()):
+		message.append("{:d}: ".format(chassis))
+		role = int(attribs[2])
+		if(role == 1):
+			message.append("standalone (ERROR)")
+			critical = True
+		elif(role == 2):
+			message.append("active")
+			if(chassisId != 0):
+				message.append(" (WARNING)")
+				warning = True
+		elif(role == 3):
+			message.append("standby")
+			if(chassisId == 0):
+				message.append(" (WARNING)")
+				warning = True
+		else:
+			message.append("UNKNOWN ({:d})".format(status))
+			unknown = True
+		message.append(", up {:s}".format(datetime.timedelta(seconds=int(attribs[3])/100)))
+		message.append(", ")
+		chassisId += 1
+		
+	# Remove last trailing separator.
+	message.pop()
+	
+	message.append(".")
+	
+	result = OK
+	if(critical):
+		result = CRITICAL
+	elif(warning):
+		result = WARNING
+	elif(unknown):
+		result = UNKNOWN
+	message = "".join(message)
+	return result, message
+
+oidTablePattern = re.compile(".*\.(\d+)\.(\d+)$")
+def oidToTable(oid):
+	tab = {}
+	for member in oid:
+		match = oidTablePattern.match(member.tag)
+		tab.setdefault(int(match.group(2)), {})[int(match.group(1))] = member.val
+	return tab
 
 ###############################################################
 #
@@ -378,10 +515,14 @@ def evaluate_results(stack, ring):
 #
 ###############################################################
 def main():
-	options = parse_args()
-	stack = get_stack_info(options)
-	ring = get_ring_status(options)
-	result, message = evaluate_results(stack, ring)
+	try:
+		options = parse_args()
+		result, message = getattr(sys.modules[__name__], "run_{}".format(options["mode"]))(options)
+	except SystemExit as e:
+		sys.exit(e)
+	except:
+		traceback.print_exc()
+		sys.exit(UNKNOWN)
 	plugin_exit(result, message)
 
 

--- a/check_cisco_stack.py
+++ b/check_cisco_stack.py
@@ -36,6 +36,8 @@
 # 2015-12-04 - 1.1: Now marking all states other than "ready" as critical
 # 2015-06-06 - 1.2: Add SNMP version 2 support.
 #                   Return an exit status code of 3/UNKNOWN if -v / --version is used.
+#                   Update standard output to show # of members,
+#                   and to show members in sorted order.
 #                   (ziesemer)
 #
 # ======================= LICENSE =============================
@@ -319,10 +321,10 @@ def get_ring_status(options):
 #
 ###############################################################
 def evaluate_results(stack, ring):
-    message = ["Members: "]
+    message = [str(len(stack)), " Members:: "]
     result = OK
     logging.debug('Checking each stack member')
-    for i, member in stack.iteritems():
+    for i, member in sorted(stack.iteritems()):
         logging.debug('Member {0} is {1}'.format(member['number'], member['status']))
         message.append("{0}: {1}, ".format(member['number'], member['status']))
         if member['status_num'] is not '4':

--- a/check_cisco_stack.py
+++ b/check_cisco_stack.py
@@ -42,6 +42,9 @@
 #                   Allow supplying SNMP community string from keyed file.
 #                   (ziesemer)
 # 2016-06-07 - 1.3: Add support for Cisco VSS (Virtual Switching System) mode.
+#                   (ziesemer)
+# 2016-12-03 - 1.4: Fix "zero length field name in format" error on Python 2.6.
+#                   (ziesemer)
 #
 # ======================= LICENSE =============================
 #
@@ -517,7 +520,7 @@ def oidToTable(oid):
 def main():
 	try:
 		options = parse_args()
-		result, message = getattr(sys.modules[__name__], "run_{}".format(options["mode"]))(options)
+		result, message = getattr(sys.modules[__name__], "run_{0}".format(options["mode"]))(options)
 	except SystemExit as e:
 		sys.exit(e)
 	except:

--- a/check_cisco_stack.py
+++ b/check_cisco_stack.py
@@ -89,12 +89,12 @@ UNKNOWN = 3
 
 
 def exit_status(x):
-    return {
-        0: 'OK',
-        1: 'WARNING',
-        2: 'CRITICAL',
-        3: 'UNKNOWN'
-    }.get(x, 'UNKNOWN')
+	return {
+		0: 'OK',
+		1: 'WARNING',
+		2: 'CRITICAL',
+		3: 'UNKNOWN'
+	}.get(x, 'UNKNOWN')
 
 
 ###############################################################
@@ -103,7 +103,7 @@ def exit_status(x):
 #
 ###############################################################
 def usage():
-    print """
+	print """
 \t-h --help\t\t\t- Prints out this help message.
 \t-v --version\t\t\t- Prints the version number.
 \t-H --host <ip_address>\t\t- IP address of the cisco stack.
@@ -113,7 +113,7 @@ def usage():
 \t   --snmp-protocol-version <#>\t- SNMP protocol version.
 \t-d --debug\t\t\t- Verbose mode for debugging.
 """
-    sys.exit(UNKNOWN)
+	sys.exit(UNKNOWN)
 
 
 ###############################################################
@@ -122,79 +122,79 @@ def usage():
 #
 ###############################################################
 def parse_args():
-    options = dict([
-        ("remote_ip", None),
-        ("community", None),
-        ("community-key", None),
-        ("community-file", None),
-        ("snmp-protocol-version", 1)
-    ])
-    try:
-        opts, args = getopt.getopt(sys.argv[1:],
-            "hvH:c:d",
-            ["help", "version", "host=",
-                "community=", "community-key=", "community-file=",
-                "snmp-protocol-version=", "debug"])
-    except getopt.GetoptError, err:
-        # print help information and exit:
-        print str(err)    # will print something like "option -a not recognized"
-        usage()
-    for o, a in opts:
-        if o in ("-h", "--help"):
-            usage()
-        elif o in ("-v", "--version"):
-            print "{0} plugin version {1}".format(__program_name__, __version__)
-            sys.exit(UNKNOWN)
-        elif o in ("-H", "--host"):
-            options['remote_ip'] = a
-        elif o in ("-c", "--community"):
-            options['community'] = a
-        elif o in ("--community-key"):
-            options["community-key"] = a
-        elif o in ("--community-file"):
-            options["community-file"] = a
-        elif o in ("--snmp-protocol-version"):
-            options["snmp-protocol-version"] = int(a)
-        elif o in ("-d", "--debug"):
-            logging.basicConfig(
-                level=logging.DEBUG,
-                format='%(asctime)s - %(funcName)s - %(message)s'
-            )
-            logging.debug('*** Debug mode started ***')
-        else:
-            assert False, "unhandled option: " + o
-    
-    if(options["community-key"] or options["community-file"]):
-        if(options["community-key"] is None or options["community-file"] is None):
-            print("Neither or both of community-key and community-file must be provided.")
-            usage()
-        try:
-            # Based on http://stackoverflow.com/a/34518072/751158:
-            ignores = re.compile("^#|\s*\r?\n")
-            secrets = dict(line.strip().split("=", 1) for line in open(options["community-file"]) if not ignores.match(line))
-            options["community"] = secrets[options["community-key"]]
-        except:
-            traceback.print_exc()
-            sys.exit(UNKNOWN)
-    elif(options["community"] is None):
-        options["community"] = "Public"
-    
-    logging.debug('Printing initial variables')
-    logging.debug('remote_ip: {0}'.format(options['remote_ip']))
-    logging.debug('community: {0}'.format(options['community']))
-    logging.debug('snmp-protocol-version: {0}'.format(options['snmp-protocol-version']))
-    if options['remote_ip'] is None:
-        print "Requires host to check"
-        usage()
-    
-    snmp_kwargs = {
-        "DestHost" : options["remote_ip"],
-        "Version" : options["snmp-protocol-version"],
-        "Community" : options['community']
-    }
-    options["snmp_kwargs"] = snmp_kwargs
-    
-    return options
+	options = dict([
+		("remote_ip", None),
+		("community", None),
+		("community-key", None),
+		("community-file", None),
+		("snmp-protocol-version", 1)
+	])
+	try:
+		opts, args = getopt.getopt(sys.argv[1:],
+			"hvH:c:d",
+			["help", "version", "host=",
+				"community=", "community-key=", "community-file=",
+				"snmp-protocol-version=", "debug"])
+	except getopt.GetoptError, err:
+		# print help information and exit:
+		print str(err)    # will print something like "option -a not recognized"
+		usage()
+	for o, a in opts:
+		if o in ("-h", "--help"):
+			usage()
+		elif o in ("-v", "--version"):
+			print "{0} plugin version {1}".format(__program_name__, __version__)
+			sys.exit(UNKNOWN)
+		elif o in ("-H", "--host"):
+			options['remote_ip'] = a
+		elif o in ("-c", "--community"):
+			options['community'] = a
+		elif o in ("--community-key"):
+			options["community-key"] = a
+		elif o in ("--community-file"):
+			options["community-file"] = a
+		elif o in ("--snmp-protocol-version"):
+			options["snmp-protocol-version"] = int(a)
+		elif o in ("-d", "--debug"):
+			logging.basicConfig(
+				level=logging.DEBUG,
+				format='%(asctime)s - %(funcName)s - %(message)s'
+			)
+			logging.debug('*** Debug mode started ***')
+		else:
+			assert False, "unhandled option: " + o
+	
+	if(options["community-key"] or options["community-file"]):
+		if(options["community-key"] is None or options["community-file"] is None):
+			print("Neither or both of community-key and community-file must be provided.")
+			usage()
+		try:
+			# Based on http://stackoverflow.com/a/34518072/751158:
+			ignores = re.compile("^#|\s*\r?\n")
+			secrets = dict(line.strip().split("=", 1) for line in open(options["community-file"]) if not ignores.match(line))
+			options["community"] = secrets[options["community-key"]]
+		except:
+			traceback.print_exc()
+			sys.exit(UNKNOWN)
+	elif(options["community"] is None):
+		options["community"] = "Public"
+	
+	logging.debug('Printing initial variables')
+	logging.debug('remote_ip: {0}'.format(options['remote_ip']))
+	logging.debug('community: {0}'.format(options['community']))
+	logging.debug('snmp-protocol-version: {0}'.format(options['snmp-protocol-version']))
+	if options['remote_ip'] is None:
+		print "Requires host to check"
+		usage()
+	
+	snmp_kwargs = {
+		"DestHost" : options["remote_ip"],
+		"Version" : options["snmp-protocol-version"],
+		"Community" : options['community']
+	}
+	options["snmp_kwargs"] = snmp_kwargs
+	
+	return options
 
 
 ###############################################################
@@ -205,10 +205,10 @@ def parse_args():
 #
 ###############################################################
 def plugin_exit(exitcode, message=''):
-    logging.debug('Exiting with status {0}. Message: {1}'.format(exitcode, message))
-    status = exit_status(exitcode)
-    print '{0} {1} - {2}'.format(__program_name__, status, message)
-    sys.exit(exitcode)
+	logging.debug('Exiting with status {0}. Message: {1}'.format(exitcode, message))
+	status = exit_status(exitcode)
+	print '{0} {1} - {2}'.format(__program_name__, status, message)
+	sys.exit(exitcode)
 
 
 ###############################################################
@@ -237,28 +237,28 @@ def plugin_exit(exitcode, message=''):
 #
 ###############################################################
 def get_stack_info(options):
-    member_table = {}
-    stack_table_oid = netsnmp.VarList(netsnmp.Varbind('.1.3.6.1.4.1.9.9.500.1.2.1.1.1'))
-    logging.debug('Walking stack table -- ')
-    netsnmp.snmpwalk(stack_table_oid, **options["snmp_kwargs"])
-    if not stack_table_oid:
-        plugin_exit(CRITICAL, 'Unable to retrieve SNMP stack table')
-    for member in stack_table_oid:
-        logging.debug('Member info: {0}'.format(member.print_str()))
-        a = {'number': member.val, 'index': member.tag.rsplit('.').pop()}
-        member_table[a['index']] = a
-    stack_status_oid = netsnmp.VarList(netsnmp.Varbind('.1.3.6.1.4.1.9.9.500.1.2.1.1.6'))
-    logging.debug('Walking stack status -- ')
-    netsnmp.snmpwalk(stack_status_oid, **options["snmp_kwargs"])
-    if not stack_status_oid:
-        plugin_exit(CRITICAL, 'Unable to retrieve SNMP stack status')
-    for member in stack_status_oid:
-        logging.debug('Member info: {0}'.format(member.print_str()))
-        index = member.tag.rsplit('.').pop()
-        member_table[index]['status_num'] = member.val
-        member_table[index]['status'] = stack_state(member.val)
-    logging.debug('Stack info table to return: {0}'.format(member_table))
-    return member_table
+	member_table = {}
+	stack_table_oid = netsnmp.VarList(netsnmp.Varbind('.1.3.6.1.4.1.9.9.500.1.2.1.1.1'))
+	logging.debug('Walking stack table -- ')
+	netsnmp.snmpwalk(stack_table_oid, **options["snmp_kwargs"])
+	if not stack_table_oid:
+		plugin_exit(CRITICAL, 'Unable to retrieve SNMP stack table')
+	for member in stack_table_oid:
+		logging.debug('Member info: {0}'.format(member.print_str()))
+		a = {'number': member.val, 'index': member.tag.rsplit('.').pop()}
+		member_table[a['index']] = a
+	stack_status_oid = netsnmp.VarList(netsnmp.Varbind('.1.3.6.1.4.1.9.9.500.1.2.1.1.6'))
+	logging.debug('Walking stack status -- ')
+	netsnmp.snmpwalk(stack_status_oid, **options["snmp_kwargs"])
+	if not stack_status_oid:
+		plugin_exit(CRITICAL, 'Unable to retrieve SNMP stack status')
+	for member in stack_status_oid:
+		logging.debug('Member info: {0}'.format(member.print_str()))
+		index = member.tag.rsplit('.').pop()
+		member_table[index]['status_num'] = member.val
+		member_table[index]['status'] = stack_state(member.val)
+	logging.debug('Stack info table to return: {0}'.format(member_table))
+	return member_table
 
 
 # -- STACK STATES --
@@ -304,19 +304,19 @@ def get_stack_info(options):
 # removed - The switch is removed from the stack."
 
 def stack_state(x):
-    return {
-        '1': 'waiting',
-        '2': 'progressing',
-        '3': 'added',
-        '4': 'ready',
-        '5': 'sdmMismatch',
-        '6': 'verMismatch',
-        '7': 'featureMismatch',
-        '8': 'newMasterInit',
-        '9': 'provisioned',
-        '10': 'invalid',
-        '11': 'removed',
-    }.get(x, 'UNKNOWN')
+	return {
+		'1': 'waiting',
+		'2': 'progressing',
+		'3': 'added',
+		'4': 'ready',
+		'5': 'sdmMismatch',
+		'6': 'verMismatch',
+		'7': 'featureMismatch',
+		'8': 'newMasterInit',
+		'9': 'provisioned',
+		'10': 'invalid',
+		'11': 'removed',
+	}.get(x, 'UNKNOWN')
 
 
 ###############################################################
@@ -332,14 +332,14 @@ def stack_state(x):
 #
 ###############################################################
 def get_ring_status(options):
-    ring_status_oid = netsnmp.Varbind('.1.3.6.1.4.1.9.9.500.1.1.3.0')
-    logging.debug('Getting stack ring redundancy status -- ')
-    netsnmp.snmpget(ring_status_oid, **options["snmp_kwargs"])
-    if not ring_status_oid:
-        plugin_exit(CRITICAL, 'Unable to retrieve SNMP ring status')
-    logging.debug('Ring status: {0}'.format(ring_status_oid.print_str()))
-    stack_ring_status = ring_status_oid.val
-    return stack_ring_status
+	ring_status_oid = netsnmp.Varbind('.1.3.6.1.4.1.9.9.500.1.1.3.0')
+	logging.debug('Getting stack ring redundancy status -- ')
+	netsnmp.snmpget(ring_status_oid, **options["snmp_kwargs"])
+	if not ring_status_oid:
+		plugin_exit(CRITICAL, 'Unable to retrieve SNMP ring status')
+	logging.debug('Ring status: {0}'.format(ring_status_oid.print_str()))
+	stack_ring_status = ring_status_oid.val
+	return stack_ring_status
 
 
 ###############################################################
@@ -352,24 +352,24 @@ def get_ring_status(options):
 #
 ###############################################################
 def evaluate_results(stack, ring):
-    message = [str(len(stack)), " Members:: "]
-    result = OK
-    logging.debug('Checking each stack member')
-    for i, member in sorted(stack.iteritems()):
-        logging.debug('Member {0} is {1}'.format(member['number'], member['status']))
-        message.append("{0}: {1}, ".format(member['number'], member['status']))
-        if member['status_num'] is not '4':
-            result = CRITICAL
-            logging.debug('Status changed to CRITICAL')
-    if ring == '1':
-        message.append("Stack Ring is redundant")
-    else:
-        message.append("Stack Ring is non-redundant")
-        if result == OK:
-            result = WARNING
-            logging.debug('Status changed to WARNING')
-    message = ''.join(message)
-    return result, message
+	message = [str(len(stack)), " Members:: "]
+	result = OK
+	logging.debug('Checking each stack member')
+	for i, member in sorted(stack.iteritems()):
+		logging.debug('Member {0} is {1}'.format(member['number'], member['status']))
+		message.append("{0}: {1}, ".format(member['number'], member['status']))
+		if member['status_num'] is not '4':
+			result = CRITICAL
+			logging.debug('Status changed to CRITICAL')
+	if ring == '1':
+		message.append("Stack Ring is redundant")
+	else:
+		message.append("Stack Ring is non-redundant")
+		if result == OK:
+			result = WARNING
+			logging.debug('Status changed to WARNING')
+	message = ''.join(message)
+	return result, message
 
 
 ###############################################################
@@ -378,12 +378,12 @@ def evaluate_results(stack, ring):
 #
 ###############################################################
 def main():
-    options = parse_args()
-    stack = get_stack_info(options)
-    ring = get_ring_status(options)
-    result, message = evaluate_results(stack, ring)
-    plugin_exit(result, message)
+	options = parse_args()
+	stack = get_stack_info(options)
+	ring = get_ring_status(options)
+	result, message = evaluate_results(stack, ring)
+	plugin_exit(result, message)
 
 
 if __name__ == "__main__":
-    main()
+	main()

--- a/check_cisco_stack.py
+++ b/check_cisco_stack.py
@@ -277,7 +277,7 @@ def parse_args():
 				"community=", "snmp-protocol-version="
 			]
 			+ snmp_kwargs_listopts)
-	except getopt.GetoptError, err:
+	except getopt.GetoptError as err:
 		# print help information and exit:
 		print(str(err)) # will print something like "option -a not recognized"
 		usage()
@@ -427,40 +427,20 @@ def get_stack_info(options):
 # http://tools.cisco.com/Support/SNMP/do/BrowseOID.do?
 #   objectInput=1.3.6.1.4.1.9.9.500.1.2.1.1.6&translate=Translate&submitValue=SUBMIT
 #
-#
-# "The current state of a switch:
-#
-# waiting - Waiting for a limited time on other
-# switches in the stack to come online.
-#
-# progressing - Master election or mismatch checks in
-# progress.
-#
-# added - The switch is added to the stack.
-#
-# ready - The switch is operational.
-#
-# sdmMismatch - The SDM template configured on the master
-# is not supported by the new member.
-#
-# verMismatch - The operating system version running on the
-# master is different from the operating
-# system version running on this member.
-#
-# featureMismatch - Some of the features configured on the
-# master are not supported on this member.
-#
-# newMasterInit - Waiting for the new master to finish
-# initialization after master switchover
-# (Master Re-Init).
-#
-# provisioned - The switch is not an active member of the
-# stack.
-#
-# invalid - The switch's state machine is in an
-# invalid state.
-#
-# removed - The switch is removed from the stack."
+# The current state of a switch:
+# - waiting - Waiting for a limited time on other switches in the stack to come online.
+# - progressing - Master election or mismatch checks in progress.
+# - added - The switch is added to the stack.
+# - ready - The switch is operational.
+# - sdmMismatch - The SDM template configured on the master is not supported by the new member.
+# - verMismatch - The operating system version running on the master is different from the operating
+#     system version running on this member.
+# - featureMismatch - Some of the features configured on the master are not supported on this member.
+# - newMasterInit - Waiting for the new master to finish initialization after master switchover
+#     (Master Re-Init).
+# - provisioned - The switch is not an active member of the stack.
+# - invalid - The switch's state machine is in an invalid state.
+# - removed - The switch is removed from the stack.
 
 def stack_state(x):
 	return stackStates.get(x, "UNKNOWN")


### PR DESCRIPTION
- Add SNMP version 2 support.
- Return an exit status code of 3/UNKNOWN if `-v` / `--version` is used.
- Update standard output to show # of members, and to show members in sorted order.
- Allow supplying SNMP community string from keyed file.
